### PR TITLE
[PATCH] Do not raise an error on stopping un-started timer

### DIFF
--- a/pymetrics/instruments.py
+++ b/pymetrics/instruments.py
@@ -250,7 +250,7 @@ class Timer(Histogram):
         Stops the timer.
         """
         if self._start_time is None:
-            raise ValueError('Cannot stop a timer before it has started')
+            return  # Cannot stop a timer before it has started
         self._running_value += time.time() - self._start_time
         self._start_time = None
 

--- a/tests/unit/test_instruments.py
+++ b/tests/unit/test_instruments.py
@@ -283,5 +283,9 @@ def test_timer():
 
     assert repr(timer) == 'Timer(name="test.timer.3", value=3312)'
 
-    with pytest.raises(ValueError):
-        timer.stop()
+    # make sure no error is raised, nothing happens
+    timer.stop()
+    timer.stop()
+    timer.stop()
+
+    assert repr(timer) == 'Timer(name="test.timer.3", value=3312)'


### PR DESCRIPTION
When code uses freezegun in tests, it can cause a timer to think it's being stopped when it hasn't been started. There's no need for the error; just return.