### PR TITLE
[MAJOR] Remove legacy configuration format version 1

### DIFF
--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -16,81 +16,20 @@ class TestConfiguration(object):
 
         assert "0: Invalid switch value '92'" in error_context.value.args[0]
 
-    def test_create_config_v1_extra_key(self):  # type: () -> None
+    def test_create_config_v1_has_been_retired(self):  # type: () -> None
         with pytest.raises(ValidationError) as error_context:
             create_configuration({
                 'version': 1,
-                'unknown_key': 'Unexpected key',
+                'error_logger_name': 'py_metrics_errors',
+                'enable_meta_metrics': True,
                 'publishers': [
+                    {'class': 'pymetrics.publishers.statsd.StatsdPublisher', 'host': 'localhost', 'port': 9876},
                     {'class': 'pymetrics.publishers.logging.LogPublisher', 'log_name': 'py_metrics'},
+                    {'class': 'pymetrics.publishers.null.NullPublisher'},
                 ],
             })
 
-        assert '0: Extra keys present: unknown_key' in error_context.value.args[0]
-
-    def test_create_config_v1_missing_publishers(self):  # type: () -> None
-        with pytest.raises(ValidationError) as error_context:
-            create_configuration({
-                'version': 1,
-            })
-
-        assert '0.publishers: Missing key: publishers' in error_context.value.args[0]
-
-    def test_create_config_v1_invalid_publisher(self):  # type: () -> None
-        with pytest.raises(ValidationError) as error_context:
-            create_configuration({
-                'version': 1,
-                'publishers': [
-                    {'not_a_publisher': 'nope'},
-                ],
-            })
-
-        assert '0.publishers.0.class: Missing key: class' in error_context.value.args[0]
-
-    def test_create_config_v1_non_existent_publisher(self):  # type: () -> None
-        with pytest.raises(ValidationError) as error_context:
-            create_configuration({
-                'version': 1,
-                'publishers': [
-                    {'class': 'pymetrics.publishers.NotARealPublisher'},
-                ],
-            })
-
-        assert 'Could not import publisher' in error_context.value.args[0]
-
-    def test_create_config_v1_success(self):  # type: () -> None
-        configuration = create_configuration({
-            'version': 1,
-            'publishers': [
-                {'class': 'pymetrics.publishers.logging.LogPublisher', 'log_name': 'py_metrics'},
-            ],
-        })
-
-        assert configuration.version == 1
-        assert configuration.error_logger_name is None
-        assert configuration.enable_meta_metrics is False
-        assert len(configuration.publishers) == 1
-        assert configuration.publishers[0].__class__.__name__ == 'LogPublisher'
-
-    def test_create_config_v1_success_optional_settings(self):  # type: () -> None
-        configuration = create_configuration({
-            'version': 1,
-            'error_logger_name': 'py_metrics_errors',
-            'enable_meta_metrics': True,
-            'publishers': [
-                {'class': 'pymetrics.publishers.statsd.StatsdPublisher', 'host': 'localhost', 'port': 9876},
-                {'class': 'pymetrics.publishers.logging.LogPublisher', 'log_name': 'py_metrics'},
-                {'class': 'pymetrics.publishers.null.NullPublisher'},
-            ],
-        })
-
-        assert configuration.version == 1
-        assert configuration.error_logger_name == 'py_metrics_errors'
-        assert configuration.enable_meta_metrics is True
-        assert len(configuration.publishers) == 3
-        assert configuration.publishers[0].__class__.__name__ == 'StatsdPublisher'
-        assert configuration.publishers[1].__class__.__name__ == 'LogPublisher'
-        assert configuration.publishers[2].__class__.__name__ == 'NullPublisher'
+        assert "0: Invalid switch value '1'" in error_context.value.args[0]
 
     def test_create_config_v2_extra_key(self):  # type: () -> None
         with pytest.raises(ValidationError) as error_context:


### PR DESCRIPTION
The "version 1" configuration format is a remnant of our pre-open-source version of this library and was kept around for backwards compatibility. All uses of the "version 1" configuration format across all of our projects have been migrated to "version 2" now, so we are removing it here and then releasing 1.0.0.