### PR TITLE
bump version of python in deploy stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
         - mypy . --exclude=build
     - stage: deploy
       if: tag =~ ^[0-9]+\.[0-9]+\.[0-9]+
-      python: '3.6'
+      python: '3.7'
       script: skip
       install:
         - pip install -U pip setuptools pyopenssl


### PR DESCRIPTION
The last deployment attempt I made got the following error.
<img width="1150" alt="image" src="https://user-images.githubusercontent.com/97697705/211398705-2a109f2f-0e52-4b68-9f7d-23345a41e782.png">
This PR bumps the version of python for the deployment stage so I can try the deploy stage again.