### PR TITLE
Bump typing extension range

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ install_requires = [
     'enum34;python_version<"3.4"',
     'six',
     'typing~=3.7.4;python_version<"3.5"',
-    'typing-extensions~=3.7.4;python_version<"3.8"',
+    'typing-extensions~=3.10;python_version<"3.8"',
 ]
 
 mypy_require = [


### PR DESCRIPTION
Another compatibility issue came up with pysoa requiring a higher typing extensions version than pymetrics currently allows. Bumping the range here.