### PR TITLE
[PATCH] Install requires typing-extensions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,13 +27,13 @@ install_requires = [
     'enum34;python_version<"3.4"',
     'six',
     'typing~=3.7.4;python_version<"3.5"',
+    'typing-extensions~=3.10;python_version<"3.8"',
 ]
 
 mypy_require = [
     'mypy~=0.740;python_version>"3.4"',
     'types-six~=0.1.7;python_version>"3.4"',
     'types-mock~=0.1.3;python_version>"3.4"',
-    'typing-extensions~=3.10;python_version<"3.8"',
     ]
 
 tests_require = [


### PR DESCRIPTION
Add `typing-extensions` to `install_requires` to resolve errors like [this one](https://app.circleci.com/pipelines/github/eventbrite/risk_utils/163/workflows/1e6c8fd8-9e98-428b-889c-e7e1e52c9c2c/jobs/150), where an `ImportError` occurs when using python 3.5