### PR TITLE
[PATCH] Fix Travis CI deploy step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: xenial
+dist: focal
 language: python
 matrix:
   include:

--- a/tasks.py
+++ b/tasks.py
@@ -10,4 +10,5 @@ from invoke_release.tasks import *  # noqa: F403
 configure_release_parameters(  # noqa: F405
     module_name='pymetrics',
     display_name='PyMetrics',
+    use_pull_request=True,
 )


### PR DESCRIPTION
After #17 was merged, the Travis CI step to deploy the release to PyPI [failed](https://app.travis-ci.com/github/eventbrite/pymetrics/jobs/613930806) due to the Ubuntu Xenial distribution having an older version of OpenSSL. Hopefully, by upgrading to the Focal distribution this will be resolved without having to constrain the `urllib3` version

Update: The build jobs for this PR show that the new distribution has a newer version of OpenSSL 🎉 

<img width="217" alt="image" src="https://github.com/eventbrite/pymetrics/assets/92889651/518d8a74-298e-4c30-92ec-c60d73aa7011">
